### PR TITLE
Update tao dependency

### DIFF
--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -58,10 +58,10 @@ serde = { version = "1", optional = true, features = [ "derive" ] }
   workspace = true
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
-egui-winit = { package = "egui-tao", version = "0.23.0", path = "../egui-winit", default-features = false, features = [ "clipboard", "links" ] }
+egui-winit = { package = "egui-tao",  version = "0.23.0", path = "../egui-winit", default-features = false, features = [ "clipboard", "links" ] }
 image = { version = "0.24", default-features = false, features = [ "png" ] }
-raw-window-handle = { version = "0.5.0" }
-winit = { package = "tao", version = "0.19.0" }
+raw-window-handle = { version = "0.5.0"}
+winit = { package = "tao", version = "0.26" }
 directories-next = { version = "2", optional = true }
 pollster = { version = "0.3", optional = true }
 glutin = { version = "0.30", optional = true }

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -58,9 +58,9 @@ serde = { version = "1", optional = true, features = [ "derive" ] }
   workspace = true
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
-egui-winit = { package = "egui-tao",  version = "0.23.0", path = "../egui-winit", default-features = false, features = [ "clipboard", "links" ] }
+egui-winit = { package = "egui-tao", version = "0.23.0", path = "../egui-winit", default-features = false, features = [ "clipboard", "links" ] }
 image = { version = "0.24", default-features = false, features = [ "png" ] }
-raw-window-handle = { version = "0.5.0"}
+raw-window-handle = { version = "0.5.0" }
 winit = { package = "tao", version = "0.26" }
 directories-next = { version = "2", optional = true }
 pollster = { version = "0.3", optional = true }


### PR DESCRIPTION
This PR updates `tao` dependency to the latest version 0.26, which depends on gdk-sys 0.18. This should solve the following error:
```
error: failed to select a version for `gdk-sys`.
    ... required by package `tao v0.18.0`
    ... which satisfies dependency `winit = "^0.18.0"` of package `eframe_tao v0.23.0`
    ... which satisfies dependency `eframe = "^0.23.0"` of package `tauri-egui v0.3.0`
    ... which satisfies git dependency `tauri-egui` of package `my-tauri-app v0.0.0`
versions that meet the requirements `^0.16` are: 0.16.0

the package `gdk-sys` links to the native library `gdk-3`, but it conflicts with a previous package which links to `gdk-3` as well:
package `gdk-sys v0.18.0`
    ... which satisfies dependency `gdk-sys = "^0.18.0"` (locked to 0.18.0) of package `webkit2gtk v2.0.1`
    ... which satisfies dependency `webkit2gtk = "=2.0.1"` (locked to 2.0.1) of package `tauri v2.0.0-beta.13`
    ... which satisfies dependency `tauri = "^2.0.0-beta"` (locked to 2.0.0-beta.13) of package `my-tauri-app v0.0.0`
```